### PR TITLE
удалять файлы с форсом

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ PackageCleaner.prototype.deleteFiles = function() {
 
 PackageCleaner.prototype.setDryRunMethods = function() {
     this._deleteDirMethod = function(p) { console.log('rm -rf ' + p)};
-    this._deleteFileMethod = function(p) { console.log('rm ' + p)};
+    this._deleteFileMethod = function(p) { console.log('rm -f ' + p)};
     this._copyMethod = function(f, t) { console.log('cp ' + f + ' ' + t)};
     this._makeTreeMethod = function(p) { console.log('mkdir -p ' + p)};
     return this;


### PR DESCRIPTION
когда make --jobs чистит несколько папок одновременно, могут попасться
файлы, которые уже были удалены
![image](https://cloud.githubusercontent.com/assets/5292544/11609287/de099e40-9b93-11e5-85b5-1f55b11532cb.png)
